### PR TITLE
Add support for uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,19 @@ Adds Chinese phonetic scripts to .epub files
 * Jyutping (comming soon)
 
 # Requirements
+* [uv](https://docs.astral.sh/uv/)
+
+or
+
 * https://github.com/TTWNO/dragonmapper <develop branch>
 * python(3) beautifulsoup4
 * python(3) jieba
 * python(3) ebooklib
 * python(3) lxml
 
-# Instalation
+# Installation
+
+* If you are using [`uv`](https://docs.astral.sh/uv/), just make sure `uv` is installed and there is nothing else to do.
 
 * If you are on Linux, and are using python3
 

--- a/add-pinyin.sh
+++ b/add-pinyin.sh
@@ -4,18 +4,22 @@ fullfilename="$1"
 extension="${fullfilename##*.}"
 filename="${fullfilename%.*}"
 
-mkdir "$filename"
+mkdir -p "$filename"
 cd "$filename"
 unzip -q "../$fullfilename"
 cd ..
 
-mkdir "$filename-with-pinyin"
+mkdir -p "$filename-with-pinyin"
 cp -r "$filename" "$filename-with-pinyin"
-mkdir "$filename-with-pinyin/$filename/OEBPS/js" || mkdir "$filename-with-pinyin/$filename/OPS/js" && echo "Alternate path found"
+mkdir -p "$filename-with-pinyin/$filename/OEBPS/js" || mkdir -p "$filename-with-pinyin/$filename/OPS/js" && echo "Alternate path found"
 cp "js/functions.js" "$filename-with-pinyin/$filename/OEBPS/js/" || cp "js/functions.js" "$filename-with-pinyin/$filename/OPS/js/" && echo "Alternate path found"
 
-echo "Starting the python3 program:"
-python3 main.py "$fullfilename"
+echo "Starting the Python program:"
+if command -v uv &> /dev/null; then
+    uv run main.py "$fullfilename"
+else
+    python3 main.py "$fullfilename"
+fi
 
 echo "Creating new epub file"
 cd "$filename-with-pinyin"

--- a/main.py
+++ b/main.py
@@ -1,4 +1,19 @@
 #!/bin/python3.4
+# /// script
+# requires-python = "<3.10"
+# dependencies = [
+#     "beautifulsoup4==4.6.0",
+#     "hanzidentifier==1.2.0",
+#     "dragonmapper",
+#     "ebooklib==0.15",
+#     "jieba==0.38",
+#     "lxml",
+# ]
+# [tool.uv]
+# exclude-newer = "2024-10-06T00:00:00Z"
+# [tool.uv.sources]
+# dragonmapper = { git = "https://github.com/TTWNO/dragonmapper", branch = "develop" }
+# ///
 # -*- coding: utf-8 -*-
 """A Python app that makes epub files with pinyin in them."""
 


### PR DESCRIPTION
I wanted to use this project recently and as is often the case with older Python projects, it took a few tries to get all the dependencies right.  
To make this easier, I added dependency definitions for `uv` to trivialize dependency management. This way, there is no need to install the right Python version, pip version, create venv etc.